### PR TITLE
Add support for build args

### DIFF
--- a/docker-build-and-release/action.yml
+++ b/docker-build-and-release/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Build path for Docker (default: .)'
     required: true
     default: '.'
+  args:
+    description: 'Additional arguments for Docker build. (eg. --build-arg NAME="NAME")'
+    required: true
+    default: ''
 
 outputs:
   image-id:
@@ -35,7 +39,7 @@ runs:
     
     - id: docker-build
       name: 'Build new image'
-      run: docker build --build-arg BUILD_ID="$GITHUB_RUN_NUMBER" --cache-from "${{ inputs.image }}" --tag "${{ inputs.image }}" "${{ inputs.path }}"
+      run: docker build --build-arg BUILD_ID="$GITHUB_RUN_NUMBER" ${{ inputs.args }} --cache-from "${{ inputs.image }}" --tag "${{ inputs.image }}" "${{ inputs.path }}"
       shell: bash
 
     - id: docker-tag-job


### PR DESCRIPTION
Users can now supply the action with `args` input, allowing them to define some additional build-args, for example.