### PR TITLE
Use v4 of setup-python with caching

### DIFF
--- a/flake8/action.yml
+++ b/flake8/action.yml
@@ -20,9 +20,10 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+        cache: 'pip'
 
     - id: install
       name: Install flake8

--- a/pyblack/action.yml
+++ b/pyblack/action.yml
@@ -20,9 +20,10 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+        cache: 'pip'
 
     - id: install
       name: Install black

--- a/pycoverage/action.yml
+++ b/pycoverage/action.yml
@@ -28,9 +28,10 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+        cache: 'pip'
 
     - id: install
       name: Install dependencies

--- a/pytest/action.yml
+++ b/pytest/action.yml
@@ -23,9 +23,10 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+        cache: 'pip'
 
     - id: install
       name: Install dependencies

--- a/vulture/action.yml
+++ b/vulture/action.yml
@@ -24,9 +24,10 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+        cache: 'pip'
 
     - id: install
       name: Install dependencies


### PR DESCRIPTION
This upgrades our usage of `actions/setup-python` to current latest version, and also enables pip caching of dependencies, which speeds up builds and reduces waste of resources.

See: <https://github.com/actions/setup-python#caching-packages-dependencies>