### PR TITLE
Use docker-container as the build driver in Docker build workflows

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -18,6 +18,7 @@ inputs:
     description: "Use cache"
     required: true
     default: "yes"
+  
   args:
     description: 'Additional arguments for Docker build. (eg. --build-arg NAME="NAME")'
     required: true
@@ -31,15 +32,24 @@ outputs:
 runs:
   using: composite
   steps:
+    - id: docker-build-setup
+      name: 'Setup a customer builder'
+      shell: bash
+      run: |
+        docker buildx create \
+          --name seravo-customer-builder \
+          --driver docker-container
+
     - id: docker-build
       name: 'Build new image'
       run: |
-        docker buildx build \
+        docker buildx --builder seravo-customer-builder build \
           --label "org.opencontainers.image.revision=${{ github.sha }}" \
           -f "${{ inputs.path }}/${{ inputs.dockerfile }}" \
           ${{ inputs.args }} \
           ${{ inputs.cache == 'no' && '--no-cache' || '' }} \
           --cache-from "${{ inputs.image }}" \
+          --load \
           --tag "${{ inputs.image }}" \
           "${{ inputs.path }}"
       shell: bash

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -18,7 +18,10 @@ inputs:
     description: "Use cache"
     required: true
     default: "yes"
-  
+  default-cache:
+    description: "Use cache from input image"
+    required: true
+    default: "yes"
   args:
     description: 'Additional arguments for Docker build. (eg. --build-arg NAME="NAME")'
     required: true
@@ -48,7 +51,7 @@ runs:
           -f "${{ inputs.path }}/${{ inputs.dockerfile }}" \
           ${{ inputs.args }} \
           ${{ inputs.cache == 'no' && '--no-cache' || '' }} \
-          --cache-from "${{ inputs.image }}" \
+          ${{ inputs.default-cache == 'yes' && '--cache-from ${{ inputs.image }}' || '' }} \
           --load \
           --tag "${{ inputs.image }}" \
           "${{ inputs.path }}"


### PR DESCRIPTION
The default builder lacks features, which we'd like to use, namely the more advanced cache storage backends.

https://docs.docker.com/build/builders/drivers/

Support is also added for disabling the default `cache-from` directive regarding the input image.