### PR TITLE
Misc fixes

### DIFF
--- a/docker-build-and-release/action.yml
+++ b/docker-build-and-release/action.yml
@@ -17,6 +17,18 @@ inputs:
     description: 'Additional arguments for Docker build. (eg. --build-arg NAME="NAME")'
     required: false
     default: ''
+  dockerfile:
+    description: 'Name of Dockerfile'
+    required: true
+    default: 'Dockerfile'
+  cache:
+    description: "Use cache"
+    required: true
+    default: "yes"
+  default-cache:
+    description: "Use cache from input image"
+    required: true
+    default: "yes"
 
 runs:
   using: composite
@@ -49,6 +61,9 @@ runs:
         image: "${{ inputs.image_name}}:${{ steps.clean-tag.outputs.tag }}"
         path: ${{ inputs.path }}
         args: ${{ inputs.args }}
+        dockerfile: ${{ inputs.dockerfile }}
+        cache: ${{ inputs.cache }}
+        default-cache: ${{ inputs.default-cache }}
 
     - name: Push new ${{ inputs.image_name}} image to registry
       id: docker-push-master

--- a/docker-build-and-release/action.yml
+++ b/docker-build-and-release/action.yml
@@ -41,7 +41,7 @@ runs:
       name: Login to GitHub Container Registry
 
     # To speed up builds, try to use previously built image as cache source.
-    - if: ${{ github.event_name != 'schedule' }}
+    - if: ${{ github.event_name != 'schedule' && inputs.cache == 'yes' }}
       name: Pull previously built image
       id: docker-pull
       uses: Seravo/actions/docker-pull@v1.10.0

--- a/docker-build-and-release/action.yml
+++ b/docker-build-and-release/action.yml
@@ -33,9 +33,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
     - id: docker-login
       uses: Seravo/actions/docker-login@v1.10.0
       name: Login to GitHub Container Registry

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -43,11 +43,19 @@ runs:
           --name seravo-customer-builder \
           --driver docker-container
 
+    - id: read-git-version
+      name: 'Read version information with git'
+      shell: bash
+      run: |
+        git fetch --tags && \
+        echo "version=$(git describe --always)" >> $GITHUB_OUTPUT
+
     - id: docker-build
       name: 'Build new image'
       run: |
         docker buildx --builder seravo-customer-builder build \
           --label "org.opencontainers.image.revision=${{ github.sha }}" \
+          --label "org.opencontainers.image.version=${{ steps.read-git-version.outputs.version }}" \
           -f "${{ inputs.path }}/${{ inputs.dockerfile }}" \
           ${{ inputs.args }} \
           ${{ inputs.cache == 'no' && '--no-cache' || '' }} \


### PR DESCRIPTION
 - pass certain inputs from docker-build-and-release to docker-build action
 - pull images only if cache is enabled
 - do not checkout repository as part of the build + release, we should do that outside the action (so that repo workflow controls the state)
 - set version label using output from `git describe` to distribute tag/version info as part of the image in addition to commits