### PR TITLE
Use latest version for the dependencies

### DIFF
--- a/docker-build-and-release/action.yml
+++ b/docker-build-and-release/action.yml
@@ -38,14 +38,14 @@ runs:
   using: composite
   steps:
     - id: docker-login
-      uses: Seravo/actions/docker-login@v1.10.0
+      uses: Seravo/actions/docker-login@v1.15.0
       name: Login to GitHub Container Registry
 
     # To speed up builds, try to use previously built image as cache source.
     - if: ${{ github.event_name != 'schedule' && inputs.cache == 'yes' }}
       name: Pull previously built image
       id: docker-pull
-      uses: Seravo/actions/docker-pull@v1.10.0
+      uses: Seravo/actions/docker-pull@v1.15.0
       with:
         image: ${{ inputs.image_name }}
       continue-on-error: true
@@ -56,7 +56,7 @@ runs:
       run: echo "tag=$(echo "${{ inputs.tag }}" |sed 's/\//-/g')" >> $GITHUB_OUTPUT
 
     - id: docker-build
-      uses: Seravo/actions/docker-build@v1.10.0
+      uses: Seravo/actions/docker-build@v1.15.0
       name: Build image
       with:
         image: "${{ inputs.image_name}}:${{ steps.clean-tag.outputs.tag }}"
@@ -68,7 +68,7 @@ runs:
 
     - name: Push new ${{ inputs.image_name}} image to registry
       id: docker-push-master
-      uses: Seravo/actions/docker-push@v1.10.0
+      uses: Seravo/actions/docker-push@v1.15.0
       with:
         image: "${{ inputs.image_name }}:${{ steps.clean-tag.outputs.tag }}"
 

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - id: read-features
       name: Read repository features
-      uses: Seravo/actions/features@v1.13.0
+      uses: Seravo/actions/features@v1.15.0
 
     - id: docker-build
       name: 'Build new image'

--- a/docker-pull-previous/action.yml
+++ b/docker-pull-previous/action.yml
@@ -17,28 +17,28 @@ runs:
 
     - id: docker-pull
       name: 'Pull image from repository'
-      uses: Seravo/actions/docker-pull@v1.2.3
+      uses: Seravo/actions/docker-pull@v1.15.0
       with:
         image: "${{ inputs.image }}"
       continue-on-error: true
     
     - id: docker-pull-run
       name: 'Pull image from repository by run number'
-      uses: Seravo/actions/docker-pull@v1.2.3
+      uses: Seravo/actions/docker-pull@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ github.run_number }}"
       continue-on-error: true
     
     - name: 'Pull previously built image by commit id'
       id: docker-pull-commit
-      uses: Seravo/actions/docker-pull@v1.2.3
+      uses: Seravo/actions/docker-pull@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ github.sha }}"
       continue-on-error: true
       
     - name: 'Pull previously built image by refname'
       id: docker-pull-refname
-      uses: Seravo/actions/docker-pull@v1.2.3
+      uses: Seravo/actions/docker-pull@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ steps.refname.outputs.refname }}"
       continue-on-error: true

--- a/docker-push-build/action.yml
+++ b/docker-push-build/action.yml
@@ -17,39 +17,39 @@ runs:
     
     - id: docker-tag-run
       name: Tag image with run number
-      uses: Seravo/actions/docker-tag@v1.2.3
+      uses: Seravo/actions/docker-tag@v1.15.0
       with:
         source: "${{ inputs.image }}"
         target: "${{ inputs.image }}-${{ github.run_number }}"
 
     - id: docker-push-run
       name: Push image with run number
-      uses: Seravo/actions/docker-push@v1.2.3
+      uses: Seravo/actions/docker-push@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ github.run_number }}"
     
     - id: docker-tag-commit
       name: Tag image with commit id
-      uses: Seravo/actions/docker-tag@v1.2.3
+      uses: Seravo/actions/docker-tag@v1.15.0
       with:
         source: "${{ inputs.image }}"
         target: "${{ inputs.image }}-${{ github.sha }}"
 
     - id: docker-push-commit
       name: Push image with commit id
-      uses: Seravo/actions/docker-push@v1.2.3
+      uses: Seravo/actions/docker-push@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ github.sha }}"
     
     - id: docker-tag-refname
       name: Tag image with refname
-      uses: Seravo/actions/docker-tag@v1.2.3
+      uses: Seravo/actions/docker-tag@v1.15.0
       with:
         source: "${{ inputs.image }}"
         target: "${{ inputs.image }}-${{ steps.refname.outputs.refname }}"
 
     - id: docker-push-refname
       name: Push image with refname
-      uses: Seravo/actions/docker-push@v1.2.3
+      uses: Seravo/actions/docker-push@v1.15.0
       with:
         image: "${{ inputs.image }}-${{ steps.refname.outputs.refname }}"


### PR DESCRIPTION
This bumps all actions that reuse actions from this repository, to use the latest version (v1.15.0), which will be published from this commit.

This ensures we don't use legacy copies of the actions.