### PR TITLE
Only pull tags if needed in docker-build

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -43,12 +43,16 @@ runs:
           --name seravo-customer-builder \
           --driver docker-container
 
+    - id: pull-git-tags
+      if: ${{ github.ref_type != 'tag' }}
+      name: 'Pull tags from git'
+      shell: bash
+      run: git fetch --tags
+
     - id: read-git-version
       name: 'Read version information with git'
       shell: bash
-      run: |
-        git fetch --tags && \
-        echo "version=$(git describe --always)" >> $GITHUB_OUTPUT
+      run: echo "version=$(git describe --always)" >> $GITHUB_OUTPUT
 
     - id: read-features
       name: Read repository features


### PR DESCRIPTION
If the workflow was triggered by a tag push, we already have the tag pulled, and running this will conflict with the existing tag.

Impact: patch