### PR TITLE
Add GitHub build metadata to image version

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -63,7 +63,7 @@ runs:
       run: |
         docker buildx --builder seravo-customer-builder build \
           --label "org.opencontainers.image.revision=${{ github.sha }}" \
-          --label "org.opencontainers.image.version=${{ steps.read-git-version.outputs.version }}" \
+          --label "org.opencontainers.image.version=${{ steps.read-git-version.outputs.version }}+${{ github.run_number }}.${{ github.run_id }}.${{ github.run_attempt }}" \
           --label 'com.seravo.features=${{ steps.read-features.outputs.features }}' \
           -f "${{ inputs.path }}/${{ inputs.dockerfile }}" \
           ${{ inputs.args }} \


### PR DESCRIPTION
This makes it slightly easier to track the specific build of an image asset.

See: <https://docs.github.com/en/actions/reference/workflows-and-actions/variables>

Impact: patch
Related: ICA-38