### PR TITLE
Add semver action to parse versions

### DIFF
--- a/semver/action.yml
+++ b/semver/action.yml
@@ -1,0 +1,52 @@
+---
+name: 'SemVer Parser'
+description: 'Splits a SemVer string into major, minor, and patch components'
+inputs:
+  version:
+    description: 'The version string to parse (e.g., v1.2.3 or 1.2.3)'
+    required: true
+outputs:
+  major:
+    description: "Major version (e.g., 1)"
+    value: ${{ steps.parse.outputs.major }}
+  major_minor:
+    description: "Major and Minor version (e.g., 1.2)"
+    value: ${{ steps.parse.outputs.major_minor }}
+  full:
+    description: "Full SemVer (e.g., 1.2.3)"
+    value: ${{ steps.parse.outputs.full }}
+  raw:
+    description: "Full raw version information (without prefix v)"
+    value: ${{ steps.parse.outputs.raw }}
+  is_prerelease:
+    description: "Is this pre-release version (true/false)"
+    value: ${{ steps.parse.outputs.is_prerelease }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: parse
+      shell: bash
+      run: |
+        # 1. Strip leading 'v'
+        INPUT_VER=$(echo "${{ inputs.version }}" | sed 's/^v//')
+        
+        # 2. Extract the core SemVer (strips everything after - or +)
+        # 1.2.3-alpha.1 -> 1.2.3
+        CLEAN_VER=$(echo "$INPUT_VER" | sed -E 's/[-+].+$//')
+        
+        # 3. Split the clean version
+        MAJOR=$(echo "$CLEAN_VER" | cut -d. -f1)
+        MINOR=$(echo "$CLEAN_VER" | cut -d. -f2)
+        PATCH=$(echo "$CLEAN_VER" | cut -d. -f3)
+        
+        # 4. Set Outputs
+        echo "major=$MAJOR" >> $GITHUB_OUTPUT
+        echo "major_minor=$MAJOR.$MINOR" >> $GITHUB_OUTPUT
+        echo "full=$CLEAN_VER" >> $GITHUB_OUTPUT
+        echo "raw=$INPUT_VER" >> $GITHUB_OUTPUT # Keeps the alpha/beta suffix if needed
+        if [[ "$INPUT_VER" == *"-"* ]]; then
+          echo "is_prerelease=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_prerelease=false" >> $GITHUB_OUTPUT
+        fi


### PR DESCRIPTION
This helps to pick just major, major+minor or major+minor+patch from input version (expects semver.org compatible format).

Impact: minor
Related: ICA-38