### PR TITLE
Split Docker image:tag to two separate values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # actions
-Misc tests for GitHub actions to have much simpler implementations of certain features
+Misc tests for GitHub actions to have much simpler implementations of certain features.
+
+
+## Goals
+
+ - reduce duplication: define actions once, and reuse in workflows
+ - prevent vendor locking: avoid too hard dependencies on any external build
+   tooling, try to complete tasks with shell-script based solutions when
+   feasible

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -4,7 +4,10 @@ description: 'Build Docker image from sources'
 
 inputs:
   image:
-    description: 'Name and tag for the image to be built'
+    description: 'Name for the image to be built (eg. ghcr.io/seravo/myimage)'
+    required: true
+  tag:
+    description: 'Tag for the image to be built (eg. latest)'
     required: true
   path:
     description: 'Build path for Docker (default: .)'
@@ -70,6 +73,6 @@ runs:
           ${{ inputs.cache == 'no' && '--no-cache' || '' }} \
           ${{ inputs.default-cache == 'yes' && format('--cache-from {0}', inputs.image) || '' }} \
           --load \
-          --tag "${{ inputs.image }}" \
+          --tag "${{ inputs.image }}:${{ inputs.tag }}" \
           "${{ inputs.path }}"
       shell: bash


### PR DESCRIPTION
This makes it easier to to reuse image namespace / repository component when eg. tagging different versions.

Impact: major
Related: ICA-38