### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run linting
         uses: seravo/actions/yamllint@v1.9.0

--- a/pycoverage/action.yml
+++ b/pycoverage/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
         cache: 'pip'

--- a/pyruff-format/action.yml
+++ b/pyruff-format/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
         cache: "pip"

--- a/pyruff/action.yml
+++ b/pyruff/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
         cache: "pip"

--- a/pytest/action.yml
+++ b/pytest/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
         cache: 'pip'

--- a/vulture/action.yml
+++ b/vulture/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "Path to a dev-requirements.txt file"
     required: false
   min_confidence:
-    default: 75
+    default: "75"
     required: true
     description: "Minimum confidence for dead code to be reported"
 
@@ -24,7 +24,7 @@ runs:
   steps:
     - id: setup
       name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
         cache: 'pip'


### PR DESCRIPTION
Previous actions depended on Node 20, which is being deprecated.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Impact: patch
Related: SRV-962