### PR TITLE
Set UBUNTU_MIRROR as build variable

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -65,6 +65,7 @@ runs:
           --label "org.opencontainers.image.revision=${{ github.sha }}" \
           --label "org.opencontainers.image.version=${{ steps.read-git-version.outputs.version }}+${{ github.run_number }}.${{ github.run_id }}.${{ github.run_attempt }}" \
           --label 'com.seravo.features=${{ steps.read-features.outputs.features }}' \
+          --build-arg UBUNTU_MIRROR="${{ vars.UBUNTU_MIRROR }}" \
           -f "${{ inputs.path }}/${{ inputs.dockerfile }}" \
           ${{ inputs.args }} \
           ${{ inputs.cache == 'no' && '--no-cache' || '' }} \


### PR DESCRIPTION
This makes it possible to use our organization level variable for overriding default APT mirrors, eg. when upstream mirrors are down due to DDoS, like they have been recently.

In addition to passing the variable to the build, actual project also needs to read the variable and configure system with it.

Impact: patch
Related: SGE-2539